### PR TITLE
Improve the state of things.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Tree-wide formatting
 54cf5886e0d74eba736a2fb12b07984ff6986f50
+946044f30d3eff63f2ce8459bec3ff99dec364dc

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "easy-hosts": {
       "locked": {
-        "lastModified": 1751562656,
-        "narHash": "sha256-ISXs+9a/WSErCnCIieYU60EfaO5amh96oc+sjjU45yA=",
+        "lastModified": 1755470564,
+        "narHash": "sha256-KB1ZryVDoQcbIsItOf4WtxkHhh3ppj+XwMpSnt/2QHc=",
         "owner": "tgirlcloud",
         "repo": "easy-hosts",
-        "rev": "867059dd97fd509a2ce316101a27a2ee89076f89",
+        "rev": "d0422bc7b3db26268982aa15d07e60370e76ee1d",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1756770412,
+        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "4524271976b625a4a605beefd893f270620fd751",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752175309,
-        "narHash": "sha256-g/f7sW8EH5qRRJF95+hwWj+AzOMlw4zs04Ei5DWSRlU=",
+        "lastModified": 1758463745,
+        "narHash": "sha256-uhzsV0Q0I9j2y/rfweWeGif5AWe0MGrgZ/3TjpDYdGA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "524da5f6c0bf11bb0d5590046276423a28b9453e",
+        "rev": "3b955f5f0a942f9f60cdc9cacb7844335d0f21c3",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1751159883,
-        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "lastModified": 1754788789,
+        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
+        "lastModified": 1754340878,
+        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
+        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
         "type": "github"
       },
       "original": {
@@ -195,11 +195,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1752055615,
-        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
+        "lastModified": 1758728421,
+        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
+        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -123,18 +123,15 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1751984180,
-        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
-        "type": "github"
+        "lastModified": 1758813675,
+        "narHash": "sha256-cTjOAzgVQrjBvZLAdnY4+AhWdiAzdvEQ69/ZcxNo3Lo=",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-25.11pre866707.e643668fd71b/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs_2": {
@@ -154,18 +151,15 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1751943650,
-        "narHash": "sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4+f9C1mZQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "88983d4b665fb491861005137ce2b11a9f89f203",
-        "type": "github"
+        "lastModified": 1758655899,
+        "narHash": "sha256-0BYA4okwj38SD3W09TrogiL9MolDZekW8Sp97m5WH6M=",
+        "rev": "d1d883129b193f0b495d75c148c2c3a7d95789a0",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/25.05/nixos-25.05.810308.d1d883129b19/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.05",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz"
       }
     },
     "nixpkgs_4": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "easy-hosts": {
       "locked": {
-        "lastModified": 1747174689,
-        "narHash": "sha256-WEA2HdjC90GLf5VpMLpvOF3/uSSq6AV4DQ4ezLFspc0=",
+        "lastModified": 1751562656,
+        "narHash": "sha256-ISXs+9a/WSErCnCIieYU60EfaO5amh96oc+sjjU45yA=",
         "owner": "tgirlcloud",
         "repo": "easy-hosts",
-        "rev": "e1210563fc527221e12544ce55cd954acf94e7ed",
+        "rev": "867059dd97fd509a2ce316101a27a2ee89076f89",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749154018,
-        "narHash": "sha256-gjN3j7joRvT3a8Zgcylnd4NFsnXeDBumqiu4HmY1RIg=",
+        "lastModified": 1752175309,
+        "narHash": "sha256-g/f7sW8EH5qRRJF95+hwWj+AzOMlw4zs04Ei5DWSRlU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7aae0ee71a17b19708b93b3ed448a1a0952bf111",
+        "rev": "524da5f6c0bf11bb0d5590046276423a28b9453e",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1749494155,
-        "narHash": "sha256-FG4DEYBpROupu758beabUk9lhrblSf5hnv84v1TLqMc=",
+        "lastModified": 1751943650,
+        "narHash": "sha256-7orTnNqkGGru8Je6Un6mq1T8YVVU/O5kyW4+f9C1mZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88331c17ba434359491e8d5889cce872464052c2",
+        "rev": "88983d4b665fb491861005137ce2b11a9f89f203",
         "type": "github"
       },
       "original": {
@@ -201,11 +201,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1749194973,
-        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "lastModified": 1752055615,
+        "narHash": "sha256-19m7P4O/Aw/6+CzncWMAJu89JaKeMh3aMle1CNQSIwM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "rev": "c9d477b5d5bd7f26adddd3f96cfd6a904768d4f9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,8 @@
   };
   inputs = {
     # nixpkgs
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    nixpkgsUnstable.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-25.05/nixexprs.tar.xz";
+    nixpkgsUnstable.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
     # hm
 
@@ -41,10 +41,13 @@
     flake-parts.lib.mkFlake { inherit inputs; } (
       { ... }:
       let
-        load = { src }:
+        load =
+          { src }:
           args@{ pkgs, ... }:
-          let i = builtins.removeAttrs (args // { inherit inputs; }) [ "self" ];
-          in if (nixpkgs.lib.pathIsDirectory src) then
+          let
+            i = builtins.removeAttrs (args // { inherit inputs; }) [ "self" ];
+          in
+          if (nixpkgs.lib.pathIsDirectory src) then
             haumea.lib.load {
               inherit src;
               transformer = with haumea.lib.transformers; [
@@ -56,29 +59,40 @@
             }
           else
             haumea.lib.loaders.scoped i src;
-        multiLoad = { dir }:
-          nixpkgs.lib.mapAttrs' (name: _:
-            nixpkgs.lib.nameValuePair (nixpkgs.lib.removeSuffix ".nix" name)
-            (load { src = nixpkgs.lib.path.append dir name; }))
-          (builtins.removeAttrs (builtins.readDir dir) [ "default.nix" ]);
-      in {
+        multiLoad =
+          { dir }:
+          nixpkgs.lib.mapAttrs' (
+            name: _:
+            nixpkgs.lib.nameValuePair (nixpkgs.lib.removeSuffix ".nix" name) (load {
+              src = nixpkgs.lib.path.append dir name;
+            })
+          ) (builtins.removeAttrs (builtins.readDir dir) [ "default.nix" ]);
+      in
+      {
         imports = [
           easy-hosts.flakeModule
           devshell.flakeModule
           treefmt-nix.flakeModule
         ];
 
-        systems = [ "x86_64-linux" "aarch64-linux" ];
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+        ];
 
-        perSystem = { pkgs, ... }: {
-          treefmt = {
-            programs.nixfmt.enable = true;
-            flakeFormatter = true;
-            projectRootFile = "flake.nix";
+        perSystem =
+          { pkgs, ... }:
+          {
+            treefmt = {
+              programs.nixfmt.enable = true;
+              flakeFormatter = true;
+              projectRootFile = "flake.nix";
+            };
+
+            devshells.default = {
+              commands = [ { package = pkgs.nix; } ];
+            };
           };
-
-          devshells.default = { commands = [{ package = pkgs.nix; }]; };
-        };
 
         flake.profiles = {
           nixos = multiLoad { dir = ./nixosProfiles; };
@@ -86,20 +100,38 @@
         };
 
         flake.suites = {
-          nixos = let inherit (self.profiles) nixos;
-          in {
-            base =
-              [ nixos.core nixos.nix nixos.cachix nixos.liquidzulu nixos.root ];
-          };
-          home = let inherit (self.profiles) home;
-          in { base = [ home.direnv home.git ]; };
+          nixos =
+            let
+              inherit (self.profiles) nixos;
+            in
+            {
+              base = [
+                nixos.core
+                nixos.nix
+                nixos.cachix
+                nixos.liquidzulu
+                nixos.root
+              ];
+            };
+          home =
+            let
+              inherit (self.profiles) home;
+            in
+            {
+              base = [
+                home.direnv
+                home.git
+              ];
+            };
         };
 
-        easy-hosts = let inherit (self) profiles suites;
-        in {
-          path = ./hosts;
-          onlySystem = "x86_64-linux";
-
+        easy-hosts =
+          let
+            inherit (self) profiles suites;
+          in
+          {
+            path = ./hosts;
+            onlySystem = "x86_64-linux";
 
             shared = {
               specialArgs = {
@@ -148,10 +180,15 @@
               ];
             };
 
-          hosts = {
-            NixOS = { class = "nixos"; };
-            laptop = { class = "nixos"; };
+            hosts = {
+              NixOS = {
+                class = "nixos";
+              };
+              laptop = {
+                class = "nixos";
+              };
+            };
           };
-        };
-      });
+      }
+    );
 }

--- a/homeProfiles/doom/home.nix
+++ b/homeProfiles/doom/home.nix
@@ -11,8 +11,7 @@ in
 {
   # Doom
   activation.installDoomEmacs = hm.dag.entryAfter [ "writeBoundary" ] ''
-    export XDG_CONFIG_HOME="/home/liquidzulu/.config"
-    if [ ! -d "$XDG_CONFIG_HOME/emacs" ]; then
+    if [ ! -d "''${XDG_CONFIG_HOME:=~/.config}/emacs" ]; then
        ${lib.getExe pkgs.git} clone $VERBOSE_ARG --depth=1 --single-branch \
            "https://github.com/doomemacs/doomemacs.git" \
            "$XDG_CONFIG_HOME/emacs"

--- a/hosts/NixOS/default.nix
+++ b/hosts/NixOS/default.nix
@@ -1,4 +1,12 @@
-{ config, lib, pkgs, suites, profiles, ... }: {
+{
+  config,
+  lib,
+  pkgs,
+  suites,
+  profiles,
+  ...
+}:
+{
   imports = lib.concatLists [
     (with profiles.nixos; [
 
@@ -127,8 +135,7 @@
 
     # sysctl settings
     kernel.sysctl = {
-      "vm.max_map_count" =
-        2147483642; # https://www.youtube.com/watch?v=PsHRbfZhgXM
+      "vm.max_map_count" = 2147483642; # https://www.youtube.com/watch?v=PsHRbfZhgXM
     };
 
     # Bootloader
@@ -166,12 +173,20 @@
       #   };
       # };
 
-      availableKernelModules =
-        [ "xhci_pci" "ahci" "usbhid" "usb_storage" "sd_mod" ];
+      availableKernelModules = [
+        "xhci_pci"
+        "ahci"
+        "usbhid"
+        "usb_storage"
+        "sd_mod"
+      ];
       kernelModules = [ ];
     };
 
-    kernelModules = [ "kvm-amd" "wl" ];
+    kernelModules = [
+      "kvm-amd"
+      "wl"
+    ];
     #extraModulePackages = [ config.boot.kernelPackages.broadcom_sta ];
   };
 
@@ -274,8 +289,7 @@
   };
 
   # Hardware
-  hardware.cpu.amd.updateMicrocode =
-    lib.mkDefault config.hardware.enableRedistributableFirmware;
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/hosts/NixOS/default.nix
+++ b/hosts/NixOS/default.nix
@@ -249,7 +249,6 @@
   };
 
   # Enable sound with pipewire.
-  hardware.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {
     enable = true;

--- a/hosts/NixOS/default.nix
+++ b/hosts/NixOS/default.nix
@@ -130,9 +130,6 @@
 
   # Boot
   boot = {
-
-    kernelPackages = pkgs.linuxPackages_6_6;
-
     # sysctl settings
     kernel.sysctl = {
       "vm.max_map_count" = 2147483642; # https://www.youtube.com/watch?v=PsHRbfZhgXM

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -238,7 +238,6 @@
   };
 
   # Enable sound with pipewire.
-  hardware.pulseaudio.enable = false;
   security.rtkit.enable = true;
   services.pipewire = {
     enable = true;

--- a/nixosProfiles/blender.nix
+++ b/nixosProfiles/blender.nix
@@ -1,17 +1,3 @@
-# { config, lib, pkgs, ... }: {
-#  outputs = { self, nixpkgs, blender-bin }: {
-#    nixosConfigurations.bla = nixpkgs.lib.nixosSystem {
-#      system = "x86_64-linux";
-#      modules = [
-#        ({ config, pkgs, ... }: {
-#          nixpkgs.overlays = [ blender-bin.overlay ];
-#          environment.systemPackages = [ pkgs.blender ];
-#        })
-#      ];
-#    };
-#  };
-#}
-
 {
   config,
   lib,
@@ -19,18 +5,5 @@
   ...
 }:
 {
-  environment.systemPackages = with pkgs; [ (blender.override { cudaSupport = true; }) ];
-  # https://github.com/NixOS/nixpkgs/issues/7582
-  #nixpkgs.config.packageOverrides = self: rec {
-  #  blender = self.blender.override { cudaSupport = true; };
-  #};
-
-  # https://discourse.nixos.org/t/how-to-get-cuda-working-in-blender/5918/3
-  #nixpkgs = {
-  #  overlays = [
-  #    (final: prev: {
-  #      blender = prev.blender.override { cudaSupport = true; };
-  #    })
-  #  ];
-  #};
+  environment.systemPackages = with pkgs; [ blender ];
 }

--- a/nixosProfiles/core/default.nix
+++ b/nixosProfiles/core/default.nix
@@ -1,4 +1,10 @@
-{ config, lib, pkgs, ... }: {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
   environment = {
     # Selection of sysadmin tools that can come in handy
     systemPackages = with pkgs; [
@@ -76,7 +82,10 @@
       monospace = [ "DejaVu Sans Mono for Powerline" ];
       sansSerif = [ "DejaVu Sans" ];
     };
-    packages = with pkgs; [ powerline-fonts dejavu_fonts ];
+    packages = with pkgs; [
+      powerline-fonts
+      dejavu_fonts
+    ];
   };
 
   programs.starship = {

--- a/nixosProfiles/cuda.nix
+++ b/nixosProfiles/cuda.nix
@@ -9,4 +9,5 @@
     cudatoolkit
     cudnn
   ];
+  nixpkgs.config.cudaSupport = true;
 }

--- a/nixosProfiles/dolphin.nix
+++ b/nixosProfiles/dolphin.nix
@@ -1,3 +1,9 @@
-{ config, lib, pkgs, ... }: {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
   environment.systemPackages = with pkgs; [ kdePackages.dolphin ];
 }

--- a/nixosProfiles/fonts.nix
+++ b/nixosProfiles/fonts.nix
@@ -1,4 +1,10 @@
-{ config, lib, pkgs, ... }: {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
 
   # environment.systemPackages = with pkgs.nerd-fonts; [
   #   mononoki
@@ -11,8 +17,8 @@
 
   #environment.systemPackages = with pkgs; [ nerdfonts ];
 
-  fonts.packages = [ ] ++ builtins.filter lib.attrsets.isDerivation
-    (builtins.attrValues pkgs.nerd-fonts);
+  fonts.packages =
+    [ ] ++ builtins.filter lib.attrsets.isDerivation (builtins.attrValues pkgs.nerd-fonts);
 
   # environment.systemPackages = [ pkgs.nerd-fonts."m+" ]
   #   ++ (with pkgs.nerd-fonts; [

--- a/nixosProfiles/golang.nix
+++ b/nixosProfiles/golang.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
   environment.systemPackages = with pkgs; [ go ];

--- a/nixosProfiles/gpu.nix
+++ b/nixosProfiles/gpu.nix
@@ -1,7 +1,13 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 
 {
-  # See https://nixos.wiki/wiki/Nvidia
+  # See "https://wiki.nixos.org/wiki/NVIDIA#Enabling"
+  # TODO: This is proprietary, but we use the open source driver. Maybe we can remove this and use the default?
   services.xserver.videoDrivers = [
     "nvidia" # https://github.com/NixOS/nixpkgs/issues/80936#issuecomment-1003784682
   ];
@@ -21,8 +27,6 @@
       };
       open = true;
       nvidiaSettings = true;
-      package = config.boot.kernelPackages.nvidiaPackages.stable;
-
     };
   };
 }

--- a/nixosProfiles/nle.nix
+++ b/nixosProfiles/nle.nix
@@ -1,12 +1,19 @@
-{ config, lib, pkgs, ... }: {
-  environment.systemPackages = (with pkgs; [
-    #libsForQt5.kdenlive
-    (libsForQt5.kdenlive.overrideAttrs
-      (_: previousAttrs: { version = "22.08.3"; }))
-    glaxnimate
-    mediainfo
-    mlt
-    #davinci-resolve
-    ffmpeg
-  ]);
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  environment.systemPackages = (
+    with pkgs;
+    [
+      kdePackages.kdenlive
+      glaxnimate
+      mediainfo
+      mlt
+      #davinci-resolve
+      ffmpeg
+    ]
+  );
 }

--- a/nixosProfiles/pip.nix
+++ b/nixosProfiles/pip.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   #environment.systemPackages = with pkgs; [ python39Packages.pip ];
 }

--- a/nixosProfiles/python.nix
+++ b/nixosProfiles/python.nix
@@ -1,10 +1,15 @@
-{ config, lib, pkgs, ... }: {
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
 
-  environment.systemPackages = with pkgs;
-    [
-      python314Full
-      #python310Full
-      #(python310.withPackages
-      #  (ps: with ps; [ torch torchvision torchaudio-bin numpy ]))
-    ];
+  environment.systemPackages = with pkgs; [
+    python314Full
+    #python310Full
+    #(python310.withPackages
+    #  (ps: with ps; [ torch torchvision torchaudio-bin numpy ]))
+  ];
 }

--- a/nixosProfiles/wm.nix
+++ b/nixosProfiles/wm.nix
@@ -10,8 +10,8 @@
     displayManager.sddm.enable = true;
     displayManager.sddm.wayland.enable = true;
 
-      # Enable KDE Plasma desktop environment
-      desktopManager.plasma6.enable = true;
-    
+    # Enable KDE Plasma desktop environment
+    desktopManager.plasma6.enable = true;
+
   };
 }

--- a/oldtree/shell/devos.nix
+++ b/oldtree/shell/devos.nix
@@ -35,23 +35,22 @@ in
     editorconfig-checker
   ];
 
-  commands =
-    [
-      (devos agenix)
-      {
-        category = "devos";
-        name = nvfetcher-bin.pname;
-        help = nvfetcher-bin.meta.description;
-        command = "cd $PRJ_ROOT/pkgs; ${nvfetcher-bin}/bin/nvfetcher -c ./sources.toml $@";
-      }
+  commands = [
+    (devos agenix)
+    {
+      category = "devos";
+      name = nvfetcher-bin.pname;
+      help = nvfetcher-bin.meta.description;
+      command = "cd $PRJ_ROOT/pkgs; ${nvfetcher-bin}/bin/nvfetcher -c ./sources.toml $@";
+    }
 
-      (formatter treefmt)
-    ]
-    ++ lib.optionals (!pkgs.stdenv.buildPlatform.isi686) [
-      (devos cachix)
-    ]
-    ++ lib.optionals (pkgs.stdenv.hostPlatform.isLinux && !pkgs.stdenv.buildPlatform.isDarwin) [
-      (devos nixos-generators)
-      (devos inputs.deploy.packages.${pkgs.system}.deploy-rs)
-    ];
+    (formatter treefmt)
+  ]
+  ++ lib.optionals (!pkgs.stdenv.buildPlatform.isi686) [
+    (devos cachix)
+  ]
+  ++ lib.optionals (pkgs.stdenv.hostPlatform.isLinux && !pkgs.stdenv.buildPlatform.isDarwin) [
+    (devos nixos-generators)
+    (devos inputs.deploy.packages.${pkgs.system}.deploy-rs)
+  ];
 }


### PR DESCRIPTION
Nvidia develops their open source drivers against the LTS kernel, so we should probably stick with that. I enabled cudaSupport. `services.xserver.videoDrivers = [ "nvidia" ];` may not be necessary, so I added a comment about it. The kdenlive package you're using is going to be removed in 25.11, and it was causing me to rebuild `opencv` so I updated it to the Qt6 version.